### PR TITLE
Make menuType optional

### DIFF
--- a/Pod/Classes/DualSlideMenuViewController.swift
+++ b/Pod/Classes/DualSlideMenuViewController.swift
@@ -32,7 +32,7 @@ public class DualSlideMenuViewController: UIViewController {
     public var delegate: DualSlideMenuViewControllerDelegate?
     
     private var amountOfMenus: Int!
-    private var menuType: State!
+    private var menuType: State?
     
     public convenience init(mainViewController: UIViewController, leftMenuViewController: UIViewController) {
         self.init()


### PR DESCRIPTION
Since you're not setting the menuType when constructing with a left and right menu view controller the menuType should be optional. Otherwise it crashes as soon as you swipe.
